### PR TITLE
Fix R dependency

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,5 +21,6 @@ Imports:
     dplyr,
     acs
 Depends:
+    R (>= 2.15.0),
     choroplethr (>= 3.3.0)
 RoxygenNote: 5.0.1

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/juliasilge/choroplethrUTCensusTract.svg?branch=master)](https://travis-ci.org/juliasilge/choroplethrUTCensusTract)
+
 # choroplethrUTCensusTract
 Shapefile, Metadata, and Visualization Functions for US Census Tracts in Utah
 


### PR DESCRIPTION
This works on my local check, should work on Travis as well. I also added a badge link to your README.

Sorry you are frustrated with using Travis, the reason https://travis-ci.org/juliasilge/choroplethrUTCensusTract failed is by default travis fails the build if there are `WARNINGS` from R CMD check. If you do not want fail on warnings set `warnings_are_errors: false` in your `.travis.yml`.

Fixes #1
